### PR TITLE
A few fixes for "describe-stacks" and other error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ ___
     Wait for the stack to finish deploying then retrieve the functions' ARN
 
     ```bash
-    export CHUCKBOT_FUNCTION_ARN=$(aws cloudformation describe-stacks --stack-name  $STACK_NAME_AIML --query Stacks[0].Outputs --region $AWS_REGION | jq -r '.[] | select(.OutputKey == "ChuckBotFunction") | .OutputValue')
-    export MOVIEBOT_FUNCTION_ARN=$(aws cloudformation describe-stacks --stack-name  $STACK_NAME_AIML --query Stacks[0].Outputs --region $AWS_REGION | jq -r '.[] | select(.OutputKey == "MovieBotFunction") | .OutputValue')
+    export CHUCKBOT_FUNCTION_ARN=$(aws cloudformation describe-stacks --stack-name  $STACK_NAME_AIML --query "Stacks[0].Outputs" --region $AWS_REGION | jq -r '.[] | select(.OutputKey == "ChuckBotFunction") | .OutputValue')
+    export MOVIEBOT_FUNCTION_ARN=$(aws cloudformation describe-stacks --stack-name  $STACK_NAME_AIML --query "Stacks[0].Outputs" --region $AWS_REGION | jq -r '.[] | select(.OutputKey == "MovieBotFunction") | .OutputValue')
     echo $CHUCKBOT_FUNCTION_ARN
     echo $MOVIEBOT_FUNCTION_ARN
     ```

--- a/src/components/chatapp.js
+++ b/src/components/chatapp.js
@@ -322,7 +322,7 @@ const ChatAppWithData = compose(
         },
         update: (proxy, { data: { registerUser } }) => {
           const QUERY = {
-            query: getUser,
+            query: gql`${getUser}`,
             variables: { id: props.id }
           }
           const prev = proxy.readQuery(QUERY)


### PR DESCRIPTION
Issue 1:
Running "aws cloudformation describe-stacks --query" without double quote could result "no matches found: Stacks[0].Outputs"

Fix:
Added double quote for "describe-stacks --query"

----

Issue 2:
When user logs in the first time, the "registerUser" will create user record from DDB table "User-xxxxx".

However the "getUser" as update after mutation did report error:

`Error: Expecting a parsed GraphQL document. Perhaps you need to wrap the query string in a "gql" tag?`

The error will block further action such as searching user and starting a conversation, with error: 
`Uncaught (in promise) TypeError: Cannot read property 'userConversations' of null`

(A refresh to the page will solve the issue since the "getUser" method will return result and prevent "registerUser" from happening, but this is not a fix)

Fix:
Wrap "getUser" from "update:" after mutation "registerUser" with `gql` tag.

----

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
