### PR TITLE
Update commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ Note: This solution uses Amazon Lex. The service is only supported in us-east-1,
     Wait for the stack to finish deploying then retrieve the functions' ARN
 
     ```bash
-    export CHUCKBOT_FUNCTION_ARN=$(aws cloudformation describe-stacks --stack-name  $STACK_NAME_AIML --query "Stacks[0].Outputs" --region $AWS_REGION | jq -r '.[] | select(.OutputKey == "ChuckBotFunction") | .OutputValue')
-    export MOVIEBOT_FUNCTION_ARN=$(aws cloudformation describe-stacks --stack-name  $STACK_NAME_AIML --query "Stacks[0].Outputs" --region $AWS_REGION | jq -r '.[] | select(.OutputKey == "MovieBotFunction") | .OutputValue')
+    export CHUCKBOT_FUNCTION_ARN=$(aws cloudformation describe-stacks --stack-name  $STACK_NAME_AIML --query "Stacks[0].Outputs" --region $AWS_REGION --output json | jq -r '.[] | select(.OutputKey == "ChuckBotFunction") | .OutputValue')
+    export MOVIEBOT_FUNCTION_ARN=$(aws cloudformation describe-stacks --stack-name  $STACK_NAME_AIML --query "Stacks[0].Outputs" --region $AWS_REGION --output json | jq -r '.[] | select(.OutputKey == "MovieBotFunction") | .OutputValue')
     echo $CHUCKBOT_FUNCTION_ARN
     echo $MOVIEBOT_FUNCTION_ARN
     ```
@@ -221,6 +221,7 @@ _The chatbots retrieve information online via API calls from Lambda to [The Movi
 4. Access your public ChatQL application using the S3 Website Endpoint URL or the CloudFront URL returned by the `amplify publish` command. Share the link with friends, sign up some users, and start creating conversations, uploading images, translating, executing text-to-speech in different languages, performing sentiment analysis and exchanging messages. Be mindful PWAs require SSL, in order to test PWA functionality access the CloudFront URL (HTTPS) from a mobile device and add the site to the mobile home screen.
 
 ## Back End Setup, Back End and Front End Building, Deploying and Publishing with the Amplify Console
+
 (More info [here](https://docs.aws.amazon.com/amplify/latest/userguide/deploy-backend.html))
 
 1. Fork this repository into your own GitHub account and clone it


### PR DESCRIPTION
In step 11 of the README, the commands to store the CHUCKBOT and
MOVIEBOT ARN were failing. This was only occurring if the
user's aws-cli config was setup to use something other than
JSON for the default output. To fix the issue I changed the commands
to explicitly use json for the output type.

*Description of changes:*

I changed the commands
to explicitly use json for the output type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
