### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/backend/deploy.yaml
+++ b/backend/deploy.yaml
@@ -23,7 +23,7 @@ Resources:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: ai-lambda/index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: .
       Description: ""
       MemorySize: 1024
@@ -41,7 +41,7 @@ Resources:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: moviebot-lambda/index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: .
       Description: ""
       MemorySize: 128
@@ -50,7 +50,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: chuckbot-lambda/index.lambda_handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: .
       Description: ''
       MemorySize: 128


### PR DESCRIPTION
CloudFormation templates in aws-appsync-chat-starter-react have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.